### PR TITLE
Bugfix and adding ability to change logging level

### DIFF
--- a/examples/changeLevel.js
+++ b/examples/changeLevel.js
@@ -1,0 +1,26 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Log = require('../lib/log')
+  , log = new Log();
+
+var loop = 0;
+
+function LogStuffOnLevels(){
+  loop++;
+  log.debug('a debug message %s',loop);
+  log.info('a info message %s',loop);
+  log.notice('a notice message %s',loop);
+  log.warning('a warning message %s',loop);
+  log.error('a error message %s',loop);
+  log.critical('a critical message %s',loop);
+  log.alert('a alert message %s',loop);
+  log.emergency('a emergency message  %s',loop);
+}
+
+for(var i=0;i<8;i++){
+  log.setLevel(i);
+  LogStuffOnLevels();
+}

--- a/lib/log.js
+++ b/lib/log.js
@@ -157,6 +157,18 @@ Log.prototype = {
       );
     }
   },
+  
+  /**
+   * Change current logging level.
+   *
+   * @param  {Number} level
+   * @api public
+   */
+  
+  setLevel: function(level) {
+    if ('string' == typeof level) level = exports[level.toUpperCase()];
+    this.level = level;
+  },
 
   /**
    * Log emergency `msg`.

--- a/lib/log.js
+++ b/lib/log.js
@@ -21,8 +21,9 @@ var EventEmitter = require('events').EventEmitter;
  */
 
 var Log = exports = module.exports = function Log(level, stream){
-  if ('string' == typeof level) level = exports[level.toUpperCase()];
-  this.level = level || exports.DEBUG;
+  if ('string' === typeof level) level = exports[level.toUpperCase()];
+  if ('undefined' === typeof level) level = exports.DEBUG;
+  this.level = level;
   this.stream = stream || process.stdout;
   if (this.stream.readable) this.read();
 };


### PR DESCRIPTION
Don't know if you want both commits... 

I just wanted the ability change the logging level on the fly and subsequently noticed a bug in how defaults where overwriting the case where someone explicitly sets the log level to 0 in the constructor. I don't know why you would only log level 0 - but it probably shouldn't be overwritten by level 7 if someone creates it that way. ('0 || 7' is always 7)

Thanks for all your work and code. You rule.
