### PR TITLE
Local Time-Zone instead of GMT

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -149,7 +149,7 @@ Log.prototype = {
         return args[i++];
       });
       this.stream.write(
-          '[' + new Date().toString() + ']'
+          '[' + new Date() + ']'
         + ' ' + levelStr
         + ' ' + msg
         + '\n'


### PR DESCRIPTION
First of all, Thanks for creating & sharing log.js. I have been using it because I get all the features I need w/o un-necessary complexity. 
I however needed to modify the library for the log messages to have Local Time Zone instead of GMT. I am sure you understand the need for this as the development & infrastructure teams need local time in order to analyse logs more easily. It doesn't make sense for them to always convert from GMT to the local time. 

Since toString() and toLocaleString() return same String, I am using toString(). No other change! Please see if it makes sense for you to pull it in.
