### PR TITLE
Add colors to log messages

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,34 @@ Instead of the log level constants, you may also supply a string:
  
      log.error('oh no, failed to send mail to %s.', user.email);
 
+Turn colors on:
+
+    log.colorful();
+
+Turn colors off:
+
+    log.colorful(false);
+
+Setting up our own colors : 
+
+    log.colorful({
+        'EMERGENCY' : "\033[0;31m",
+        'ALERT'     : "\033[0;33m",
+        'CRITICAL'  : "\033[0;31m",
+        'ERROR'     : "\033[1;31m",
+        'WARNING'   : "\033[0;33m",
+        'NOTICE'    : "\033[0;36m",
+        'INFO'      : "\033[0;35m",
+        'DEBUG'     : "\033[0m"
+    });
+
+    You don't have to specify all levels, when defining colors, if you only want to specify certain levels, you just write those:
+
+    log.colorful({
+        'INFO'      : "\033[0;35m",
+        'DEBUG'     : "\033[0m"
+    })
+
 ## Reader
 
  To stream a log, simply pass a readable stream instead of a writable:

--- a/Readme.md
+++ b/Readme.md
@@ -61,6 +61,23 @@ Setting up our own colors :
         'INFO'      : "\033[0;35m",
         'DEBUG'     : "\033[0m"
     })
+    
+Setting up your own log levels:
+
+    log.customLevels([ 'COMMAND', 'DATA' ] );
+
+Which will simple add methods `command` and `data` to the `Log` object, and you can use them as the way that default log methods be used, like `log.command( "a command message")`.
+
+Also, you can setting up your own log levels and their colors at the same time:
+
+	log.customLevels({
+		COMMAND: '\033[0;31m',
+		DATA: '\033[0;31m'
+	});
+
+
+
+
 
 ## Reader
 

--- a/examples/file.js
+++ b/examples/file.js
@@ -5,8 +5,8 @@
 
 var Log = require('../lib/log')
   , fs = require('fs')
-  , stream = fs.createWriteStream(__dirname + '/file.log', { flags: 'a' })
-  , log = new Log('debug', stream);
+  // , stream = fs.createWriteStream(__dirname + '/file.log', { flags: 'a' })
+  , log = new Log('debug');
 
 log.debug('a debug message');
 log.info('a info message');

--- a/examples/file.js
+++ b/examples/file.js
@@ -6,12 +6,18 @@
 var Log = require('../lib/log')
   , fs = require('fs')
   // , stream = fs.createWriteStream(__dirname + '/file.log', { flags: 'a' })
-  , log = new Log('debug');
+  , log = new Log('debug').colorful({
+    DEBUG : '\033[1;30m',
+    NOTICE: '\033[0;32m'
+  });
 
 log.debug('a debug message');
 log.info('a info message');
 log.notice('a notice message');
 log.warning('a warning message');
+
+log.colorful(false);
+
 log.error('a error message');
 log.critical('a critical message');
 log.alert('a alert message');

--- a/examples/file.js
+++ b/examples/file.js
@@ -5,19 +5,13 @@
 
 var Log = require('../lib/log')
   , fs = require('fs')
-  // , stream = fs.createWriteStream(__dirname + '/file.log', { flags: 'a' })
-  , log = new Log('debug').colorful({
-    DEBUG : '\033[1;30m',
-    NOTICE: '\033[0;32m'
-  });
+  , stream = fs.createWriteStream(__dirname + '/file.log', { flags: 'a' })
+  , log = new Log('debug', stream);
 
 log.debug('a debug message');
 log.info('a info message');
 log.notice('a notice message');
 log.warning('a warning message');
-
-log.colorful(false);
-
 log.error('a error message');
 log.critical('a critical message');
 log.alert('a alert message');

--- a/examples/stdout-color.js
+++ b/examples/stdout-color.js
@@ -1,0 +1,31 @@
+
+/**
+ * Module dependencies.
+ */
+
+var Log = require('../lib/log')
+  , log = new Log('notice').colorful();
+
+log.debug('a debug message');
+log.info('a info message');
+log.notice('a notice message');
+log.warning('a warning message');
+
+/**
+ * Setup our own colors
+ */
+log.colorful({
+    ERROR : "\033[0;37m",
+    CRITICAL : "\033[1;36m"
+});
+
+log.error('a error message');
+log.critical('a critical message');
+log.alert('a alert message');
+
+/**
+ * Turn colors off
+ */
+log.colorful(false);
+log.emergency('a emergency %s', 'message');
+log.emergency('a really %s emergency %s', 'bad', 'message');

--- a/examples/stdout-color.js
+++ b/examples/stdout-color.js
@@ -4,12 +4,20 @@
  */
 
 var Log = require('../lib/log')
-  , log = new Log('notice').colorful();
+  , log = new Log('trace').colorful();
 
+/**
+ * Default log.
+ */
+log.trace( 'Below is default logs.');
 log.debug('a debug message');
 log.info('a info message');
 log.notice('a notice message');
 log.warning('a warning message');
+log.error('a error message');
+log.critical('a critical message');
+log.alert('a alert message');
+log.emergency('a emergency %s', 'message');
 
 /**
  * Setup our own colors
@@ -19,13 +27,40 @@ log.colorful({
     CRITICAL : "\033[1;36m"
 });
 
+log.trace( 'Below is color-customed logs.');
+log.debug('a debug message');
+log.info('a info message');
+log.notice('a notice message');
+log.warning('a warning message');
 log.error('a error message');
 log.critical('a critical message');
 log.alert('a alert message');
+log.emergency('a emergency %s', 'message');
 
 /**
- * Turn colors off
+ * Turn off color.
  */
-log.colorful(false);
+log.colorful( false );
+log.trace( 'Below is color-offed logs.');
+log.debug('a debug message');
+log.info('a info message');
+log.notice('a notice message');
+log.warning('a warning message');
+log.error('a error message');
+log.critical('a critical message');
+log.alert('a alert message');
 log.emergency('a emergency %s', 'message');
-log.emergency('a really %s emergency %s', 'bad', 'message');
+
+/**
+ * Customize levels and colors
+ */
+log.customLevels({
+    COMMAND: "\x1b[0;35m",
+    DATA: "\x1b[0;33m",
+    RESULT: "\x1b[0;36m"
+}).colorful( true).setLevel( 'result' );
+
+log.command( 'a command message' );
+log.data( 'a data message' );
+log.result( 'a result message' );
+

--- a/lib/log.js
+++ b/lib/log.js
@@ -3,7 +3,7 @@
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
  * MIT Licensed
  *
- * Colorful output messages by Couto
+ * Colorful stdout messages by Couto <lcouto87@gmail.com>
  */
 
  /**

--- a/lib/log.js
+++ b/lib/log.js
@@ -231,7 +231,7 @@ Log.prototype = {
      *
      * @param {Object|Array} levels
      * @example
-     *      `customLevels([ 'DEBUG', 'ERROR', 'WARNING' ];`
+     *      `customLevels([ 'DEBUG', 'ERROR', 'WARNING' ]);`
      *      `customLevels({ DEBUG: "\033[0m"});`
      */
     customLevels: function( levels ){

--- a/lib/log.js
+++ b/lib/log.js
@@ -178,7 +178,7 @@ Log.prototype = {
       var msg = args[0].replace(/%s/g, function(){
         return args[i++];
       });
-      if (this.stream === process.stdout) {
+      if (this.stream === process.stdout && this.useColors) {
           this.stream.write(
             exports.colors[levelStr]
             + '[' + new Date + ']'
@@ -196,6 +196,20 @@ Log.prototype = {
           );
       }
     }
+  },
+
+  colorful : function (colors) {
+      var k;
+      if (Object.prototype.toString.call(colors) === '[object Object]') {
+          for (k in colors) {
+              if (colors.hasOwnProperty(k) && exports.colors.hasOwnProperty(k)) {
+                exports.colors[k] = colors[k];
+              }
+          }
+          this.useColors = true;
+      } else if (colors === false) { this.useColors = false; }
+      else { this.useColors = true; }
+      return this;
   },
 
   /**

--- a/lib/log.js
+++ b/lib/log.js
@@ -178,7 +178,10 @@ Log.prototype = {
       var msg = args[0].replace(/%s/g, function(){
         return args[i++];
       });
-      if (this.stream === process.stdout && this.useColors) {
+      if (this.stream === process.stdout &&
+          this.useColors &&
+          exports.colors[levelStr]) {
+
           this.stream.write(
             exports.colors[levelStr]
             + '[' + new Date + ']'
@@ -202,7 +205,7 @@ Log.prototype = {
       var k;
       if (Object.prototype.toString.call(colors) === '[object Object]') {
           for (k in colors) {
-              if (colors.hasOwnProperty(k) && exports.colors.hasOwnProperty(k)) {
+              if (colors.hasOwnProperty(k)) {
                 exports.colors[k] = colors[k];
               }
           }

--- a/lib/log.js
+++ b/lib/log.js
@@ -2,7 +2,22 @@
  * Log.js
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
  * MIT Licensed
+ *
+ * Colorful output messages by Couto
  */
+
+ /**
+  * Colors Cheat-sheet
+  *     white  : "\033[1;37m",   black        : "\033[0;30m",
+  *     red    : "\033[0;31m",   light_red    : "\033[1;31m",
+  *     green  : "\033[0;32m",   light_green  : "\033[1;32m",
+  *     yellow : "\033[0;33m",   light_yellow : "\033[1;33m",
+  *     blue   : "\033[0;34m",   light_blue   : "\033[1;34m",
+  *     purple : "\033[0;35m",   light_purple : "\033[1;35m",
+  *     cyan   : "\033[0;36m",   light_cyan   : "\033[1;36m",
+  *     gray   : "\033[1;30m",   light_gray   : "\033[0;37m",
+  *     reset  : "\033[0m"
+  */
 
 /**
  * Module dependencies.
@@ -13,9 +28,9 @@ var EventEmitter = require('events').EventEmitter;
 /**
  * Initialize a `Loggeer` with the given log `level` defaulting
  * to __DEBUG__ and `stream` defaulting to _stdout_.
- * 
- * @param {Number} level 
- * @param {Object} stream 
+ *
+ * @param {Number} level
+ * @param {Object} stream
  * @api public
  */
 
@@ -27,8 +42,23 @@ var Log = exports = module.exports = function Log(level, stream){
 };
 
 /**
+ * Define Colors for levels
+ */
+exports.colors = {
+    'EMERGENCY' : "\033[0;31m",
+    'ALERT'     : "\033[0;33m",
+    'CRITICAL'  : "\033[0;31m",
+    'ERROR'     : "\033[1;31m",
+    'WARNING'   : "\033[0;33m",
+    'NOTICE'    : "\033[0;36m",
+    'INFO'      : "\033[0;35m",
+    'DEBUG'     : "\033[0m",
+    'reset'     : "\033[0m"
+}
+
+/**
  * System is unusable.
- * 
+ *
  * @type Number
  */
 
@@ -36,8 +66,8 @@ exports.EMERGENCY = 0;
 
 /**
  * Action must be taken immediately.
- * 
- * @type Number 
+ *
+ * @type Number
  */
 
 exports.ALERT = 1;
@@ -52,7 +82,7 @@ exports.CRITICAL = 2;
 
 /**
  * Error condition.
- * 
+ *
  * @type Number
  */
 
@@ -60,7 +90,7 @@ exports.ERROR = 3;
 
 /**
  * Warning condition.
- * 
+ *
  * @type Number
  */
 
@@ -68,7 +98,7 @@ exports.WARNING = 4;
 
 /**
  * Normal but significant condition.
- * 
+ *
  * @type Number
  */
 
@@ -76,7 +106,7 @@ exports.NOTICE = 5;
 
 /**
  * Purely informational message.
- * 
+ *
  * @type Number
  */
 
@@ -84,7 +114,7 @@ exports.INFO = 6;
 
 /**
  * Application debug messages.
- * 
+ *
  * @type Number
  */
 
@@ -92,16 +122,16 @@ exports.DEBUG = 7;
 
 /**
  * prototype.
- */ 
+ */
 
 Log.prototype = {
-  
+
   /**
    * Start emitting "line" events.
    *
    * @api public
    */
-  
+
   read: function(){
     var buf = ''
       , self = this
@@ -119,7 +149,7 @@ Log.prototype = {
               date: new Date(captures[1])
             , level: exports[captures[2]]
             , levelString: captures[2]
-            , msg: captures[3] 
+            , msg: captures[3]
           };
           self.emit('line', obj);
         } catch (err) {
@@ -133,7 +163,7 @@ Log.prototype = {
       self.emit('end');
     });
   },
-  
+
   /**
    * Log output message.
    *
@@ -148,12 +178,23 @@ Log.prototype = {
       var msg = args[0].replace(/%s/g, function(){
         return args[i++];
       });
-      this.stream.write(
-          '[' + new Date + ']'
-        + ' ' + levelStr
-        + ' ' + msg
-        + '\n'
-      );
+      if (this.stream === process.stdout) {
+          this.stream.write(
+            exports.colors[levelStr]
+            + '[' + new Date + ']'
+            + ' ' + levelStr
+            + ' ' + msg
+            + exports.colors.reset
+            + '\n'
+          );
+      } else {
+          this.stream.write(
+            '[' + new Date + ']'
+            + ' ' + levelStr
+            + ' ' + msg
+            + '\n'
+          );
+      }
     }
   },
 
@@ -228,7 +269,7 @@ Log.prototype = {
    *
    * @param  {String} msg
    * @api public
-   */ 
+   */
 
   info: function(msg){
     this.log('INFO', arguments);

--- a/lib/log.js
+++ b/lib/log.js
@@ -53,6 +53,7 @@ exports.colors = {
     'NOTICE'    : "\033[0;36m",
     'INFO'      : "\033[0;35m",
     'DEBUG'     : "\033[0m",
+    'TRACE'     : "\033[1;30m",
     'reset'     : "\033[0m"
 }
 
@@ -119,6 +120,15 @@ exports.INFO = 6;
  */
 
 exports.DEBUG = 7;
+
+/**
+ * Application debug messages.
+ *
+ * @type Number
+ */
+
+exports.TRACE = 8;
+
 
 /**
  * prototype.
@@ -301,7 +311,19 @@ Log.prototype = {
 
   debug: function(msg){
     this.log('DEBUG', arguments);
+  },
+
+  /**
+   * Log trace `msg`.
+   *
+   * @param  {String} msg
+   * @api public
+   */
+
+  trace: function(msg){
+    this.log('TRACE', arguments);
   }
+
 };
 
 /**

--- a/lib/log.js
+++ b/lib/log.js
@@ -4,20 +4,22 @@
  * MIT Licensed
  *
  * Colorful stdout messages by Couto <lcouto87@gmail.com>
+ *
+ * CustomLevel by Neekey<ni184775761@gmail.com>
  */
 
- /**
-  * Colors Cheat-sheet
-  *     white  : "\033[1;37m",   black        : "\033[0;30m",
-  *     red    : "\033[0;31m",   light_red    : "\033[1;31m",
-  *     green  : "\033[0;32m",   light_green  : "\033[1;32m",
-  *     yellow : "\033[0;33m",   light_yellow : "\033[1;33m",
-  *     blue   : "\033[0;34m",   light_blue   : "\033[1;34m",
-  *     purple : "\033[0;35m",   light_purple : "\033[1;35m",
-  *     cyan   : "\033[0;36m",   light_cyan   : "\033[1;36m",
-  *     gray   : "\033[1;30m",   light_gray   : "\033[0;37m",
-  *     reset  : "\033[0m"
-  */
+/**
+ * Colors Cheat-sheet
+ *     white  : "\033[1;37m",   black        : "\033[0;30m",
+ *     red    : "\033[0;31m",   light_red    : "\033[1;31m",
+ *     green  : "\033[0;32m",   light_green  : "\033[1;32m",
+ *     yellow : "\033[0;33m",   light_yellow : "\033[1;33m",
+ *     blue   : "\033[0;34m",   light_blue   : "\033[1;34m",
+ *     purple : "\033[0;35m",   light_purple : "\033[1;35m",
+ *     cyan   : "\033[0;36m",   light_cyan   : "\033[1;36m",
+ *     gray   : "\033[1;30m",   light_gray   : "\033[0;37m",
+ *     reset  : "\033[0m"
+ */
 
 /**
  * Module dependencies.
@@ -34,101 +36,88 @@ var EventEmitter = require('events').EventEmitter;
  * @api public
  */
 
-var Log = exports = module.exports = function Log(level, stream){
-  if ('string' == typeof level) level = exports[level.toUpperCase()];
-  this.level = level || exports.DEBUG;
-  this.stream = stream || process.stdout;
-  if (this.stream.readable) this.read();
+var Log = exports = module.exports = function Log(level, stream, custom) {
+
+    // Add custom levels.
+    if( custom ) this.customLevels( custom );
+    this.setLevel( level );
+    this.stream = stream || process.stdout;
+    if (this.stream.readable) this.read();
 };
 
 /**
- * Define Colors for levels
+ * Define Levels for levels.
  */
 exports.colors = {
-    'EMERGENCY' : "\033[0;31m",
-    'ALERT'     : "\033[0;33m",
-    'CRITICAL'  : "\033[0;31m",
-    'ERROR'     : "\033[1;31m",
-    'WARNING'   : "\033[0;33m",
-    'NOTICE'    : "\033[0;36m",
-    'INFO'      : "\033[0;35m",
-    'DEBUG'     : "\033[0m",
-    'TRACE'     : "\033[1;30m",
-    'reset'     : "\033[0m"
+    /**
+     * System is unusable.
+     */
+    'EMERGENCY':"\033[0;31m",
+    /**
+     * Action must be taken immediately.
+     */
+    'ALERT':"\033[0;33m",
+    /**
+     * Critical condition.
+     */
+    'CRITICAL':"\033[0;31m",
+    /**
+     * Error condition.
+     */
+    'ERROR':"\033[1;31m",
+    /**
+     * Warning condition.
+     */
+    'WARNING':"\033[0;33m",
+    /**
+     * Normal but significant condition.
+     */
+    'NOTICE':"\033[0;36m",
+    /**
+     * Purely informational message.
+     */
+    'INFO':"\033[0;35m",
+    /**
+     * Application debug messages.
+     */
+    'DEBUG':"\033[0m",
+    /**
+     * Application debug messages.
+     */
+    'TRACE':"\033[1;30m",
+    /**
+     * Reset log color.
+     */
+    'reset':"\033[0m"
 }
 
 /**
- * System is unusable.
+ * The latest enum value for level.
  *
- * @type Number
+ * @type {Number}
  */
-
-exports.EMERGENCY = 0;
+var enumCount = 0;
 
 /**
- * Action must be taken immediately.
+ * Add an new log level to exports, and assign an new enum value to it.
  *
- * @type Number
+ * @param levelName
  */
+var addLevelEnumerable = function (levelName) {
 
-exports.ALERT = 1;
+    if (!( levelName in exports )) {
+        exports[ levelName ] = ++enumCount;
+    }
 
-/**
- * Critical condition.
- *
- * @type Number
- */
+    var lowCaseLevelName = levelName.toLowerCase();
 
-exports.CRITICAL = 2;
+    if(!( lowCaseLevelName in Log.prototype )) {
 
-/**
- * Error condition.
- *
- * @type Number
- */
-
-exports.ERROR = 3;
-
-/**
- * Warning condition.
- *
- * @type Number
- */
-
-exports.WARNING = 4;
-
-/**
- * Normal but significant condition.
- *
- * @type Number
- */
-
-exports.NOTICE = 5;
-
-/**
- * Purely informational message.
- *
- * @type Number
- */
-
-exports.INFO = 6;
-
-/**
- * Application debug messages.
- *
- * @type Number
- */
-
-exports.DEBUG = 7;
-
-/**
- * Application debug messages.
- *
- * @type Number
- */
-
-exports.TRACE = 8;
-
+        Log.prototype[ lowCaseLevelName ] = function(msg){
+            this.log(levelName, arguments);
+        }
+    }
+};
 
 /**
  * prototype.
@@ -136,195 +125,157 @@ exports.TRACE = 8;
 
 Log.prototype = {
 
-  /**
-   * Start emitting "line" events.
-   *
-   * @api public
-   */
+    /**
+     * Start emitting "line" events.
+     *
+     * @api public
+     */
 
-  read: function(){
-    var buf = ''
-      , self = this
-      , stream = this.stream;
+    read:function () {
+        var buf = ''
+            , self = this
+            , stream = this.stream;
 
-    stream.setEncoding('ascii');
-    stream.on('data', function(chunk){
-      buf += chunk;
-      if ('\n' != buf[buf.length - 1]) return;
-      buf.split('\n').map(function(line){
-        if (!line.length) return;
-        try {
-          var captures = line.match(/^\[([^\]]+)\] (\w+) (.*)/);
-          var obj = {
-              date: new Date(captures[1])
-            , level: exports[captures[2]]
-            , levelString: captures[2]
-            , msg: captures[3]
-          };
-          self.emit('line', obj);
-        } catch (err) {
-          // Ignore
+        stream.setEncoding('ascii');
+        stream.on('data', function (chunk) {
+            buf += chunk;
+            if ('\n' != buf[buf.length - 1]) return;
+            buf.split('\n').map(function (line) {
+                if (!line.length) return;
+                try {
+                    var captures = line.match(/^\[([^\]]+)\] (\w+) (.*)/);
+                    var obj = {
+                        date:new Date(captures[1]), level:exports[captures[2]], levelString:captures[2], msg:captures[3]
+                    };
+                    self.emit('line', obj);
+                } catch (err) {
+                    // Ignore
+                }
+            });
+            buf = '';
+        });
+
+        stream.on('end', function () {
+            self.emit('end');
+        });
+    },
+
+    /**
+     * Log output message.
+     *
+     * @param  {String} levelStr
+     * @param  {Array} args
+     * @api private
+     */
+
+    log:function (levelStr, args) {
+        if (exports[levelStr] <= this.level) {
+            var i = 1;
+            var msg = args[0].replace(/%s/g, function () {
+                return args[i++];
+            });
+            if (this.stream === process.stdout &&
+                this.useColors &&
+                exports.colors[levelStr]) {
+
+                this.stream.write(
+                    exports.colors[levelStr]
+                        + '[' + new Date + ']'
+                        + ' ' + levelStr
+                        + ' ' + msg
+                        + exports.colors.reset
+                        + '\n'
+                );
+            } else {
+                this.stream.write(
+                    '[' + new Date + ']'
+                        + ' ' + levelStr
+                        + ' ' + msg
+                        + '\n'
+                );
+            }
         }
-      });
-      buf = '';
-    });
+    },
 
-    stream.on('end', function(){
-      self.emit('end');
-    });
-  },
+    /**
+     * Customize colors for stout.
+     *
+     * @param {Object|Boolean} colors
+     * @return {*}
+     * @example
+     *      `colorful({ DEBUG: "\033[0m"});`    set level `DEBUG` color to `\033[0m`.
+     *      `colorful(false)`   turn off color.
+     *      `colorful()` or `colorful(true)` turn on color.
+     *
+     */
+    colorful:function (colors) {
+        var k;
+        if (Object.prototype.toString.call(colors) === '[object Object]') {
+            for (k in colors) {
+                if (colors.hasOwnProperty(k)) {
+                    exports.colors[k] = colors[k];
+                }
+            }
+            this.useColors = true;
+        } else if (colors === false) {
+            this.useColors = false;
+        }
+        else {
+            this.useColors = true;
+        }
+        return this;
+    },
 
-  /**
-   * Log output message.
-   *
-   * @param  {String} levelStr
-   * @param  {Array} args
-   * @api private
-   */
+    /**
+     * Customize Levels and Colors.
+     *
+     * @param {Object|Array} levels
+     * @example
+     *      `customLevels([ 'DEBUG', 'ERROR', 'WARNING' ];`
+     *      `customLevels({ DEBUG: "\033[0m"});`
+     */
+    customLevels: function( levels ){
 
-  log: function(levelStr, args) {
-    if (exports[levelStr] <= this.level) {
-      var i = 1;
-      var msg = args[0].replace(/%s/g, function(){
-        return args[i++];
-      });
-      if (this.stream === process.stdout &&
-          this.useColors &&
-          exports.colors[levelStr]) {
+        var k;
 
-          this.stream.write(
-            exports.colors[levelStr]
-            + '[' + new Date + ']'
-            + ' ' + levelStr
-            + ' ' + msg
-            + exports.colors.reset
-            + '\n'
-          );
-      } else {
-          this.stream.write(
-            '[' + new Date + ']'
-            + ' ' + levelStr
-            + ' ' + msg
-            + '\n'
-          );
-      }
+        if( Object.prototype.toString.call( levels ) === '[object Array]' ){
+
+            for( k = 0; k < levels.length; k++ ){
+
+                addLevelEnumerable( levels[ k ] );
+            }
+        }
+        else if( Object.prototype.toString.call( levels ) === '[object Object]' ){
+            this.colorful( levels );
+
+            for( k in levels ){
+                addLevelEnumerable( k );
+            }
+        }
+
+        return this;
+    },
+
+    /**
+     * Set log level
+     *
+     * @param level
+     * @return {*}
+     */
+    setLevel: function( level ){
+
+        if ('string' == typeof level) level = exports[level.toUpperCase()];
+        this.level = level || this.level || exports.DEBUG;
+
+        return this;
     }
-  },
-
-  colorful : function (colors) {
-      var k;
-      if (Object.prototype.toString.call(colors) === '[object Object]') {
-          for (k in colors) {
-              if (colors.hasOwnProperty(k)) {
-                exports.colors[k] = colors[k];
-              }
-          }
-          this.useColors = true;
-      } else if (colors === false) { this.useColors = false; }
-      else { this.useColors = true; }
-      return this;
-  },
-
-  /**
-   * Log emergency `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  emergency: function(msg){
-    this.log('EMERGENCY', arguments);
-  },
-
-  /**
-   * Log alert `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  alert: function(msg){
-    this.log('ALERT', arguments);
-  },
-
-  /**
-   * Log critical `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  critical: function(msg){
-    this.log('CRITICAL', arguments);
-  },
-
-  /**
-   * Log error `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  error: function(msg){
-    this.log('ERROR', arguments);
-  },
-
-  /**
-   * Log warning `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  warning: function(msg){
-    this.log('WARNING', arguments);
-  },
-
-  /**
-   * Log notice `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  notice: function(msg){
-    this.log('NOTICE', arguments);
-  },
-
-  /**
-   * Log info `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  info: function(msg){
-    this.log('INFO', arguments);
-  },
-
-  /**
-   * Log debug `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  debug: function(msg){
-    this.log('DEBUG', arguments);
-  },
-
-  /**
-   * Log trace `msg`.
-   *
-   * @param  {String} msg
-   * @api public
-   */
-
-  trace: function(msg){
-    this.log('TRACE', arguments);
-  }
 
 };
+
+/**
+ * Add Default levels to exports and add methods to Log.prototype.
+ */
+Log.prototype.customLevels( exports.colors );
 
 /**
  * Inherit from `EventEmitter`.


### PR DESCRIPTION
I was in need for a small and useful utility that allowed different types of log messages, and I found yours… however since I log a lot of messages I needed colorful outputs to ease the task of looking for the right messages, since Log.js is so simple I decided to add colors to stdout messages.

My changes only affect `stdout` messages, I'm predicting that logging colors into files would be quite troublesome if they weren't parsed with the `read` method, also, I've added the `colorful()` method to turn colors on/off and edit your own colors, depending on the argument given.

Anyway, thanks for this small utility, is quite useful and simple to use =)
