### PR TITLE
Adding Log Rotation based on 'maximum lines to write before rotating' philosophy

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -14,6 +14,8 @@ var EventEmitter = require('events').EventEmitter;
  * Initialize a `Loggeer` with the given log `level` defaulting
  * to __DEBUG__ and `stream` defaulting to _stdout_.
  * 
+ * Initialize the `rotateLimit` with the given value, defaulting to 10,000 lines (inclusive).
+ * 
  * @param {Number} level 
  * @param {Object} stream 
  * @api public
@@ -24,6 +26,8 @@ var Log = exports = module.exports = function Log(level, stream){
   this.level = level || exports.DEBUG;
   this.stream = stream || process.stdout;
   if (this.stream.readable) this.read();
+  this.rotateLimit = rotateLimit || 10000;
+  this.totalLogged = 0;
 };
 
 /**
@@ -136,6 +140,7 @@ Log.prototype = {
   
   /**
    * Log output message.
+   * Emit `rotate` event after the number of logged-lines cross `rotateLimit` (specified while initializing)
    *
    * @param  {String} levelStr
    * @param  {Array} args
@@ -154,6 +159,11 @@ Log.prototype = {
         + ' ' + msg
         + '\n'
       );
+      var i = ++this.totalLogged;
+  	  if (i >= this.rotateLimit) {
+  	    this.emit('rotate');
+  		  this.totalLogged = 0;
+  	  }
     }
   },
 


### PR DESCRIPTION
Adding log-rotation feature, based on maximum number of lines to be written before rotating the logs. This can be achieved even by putting this logic outside log.js, but I thought it would be more appropriate to combine it along.

**Change details**:
Added 1 more argument: `rotateLimit` - the maximum number of lines to write before rotating
Emitting event `rotate` when this limit is crossed

**Philosophy**:
It may sound a bit strange to rotate logs in this way, but here is why I chose this way of rotating logs:
1. I didn't want the existing projects to be disturbed because of this change
2. I also didn't want to make it Mandatory for the users to rotate logs, thus only emitting an event just for notification
3. There was limited support from Node.js APIs for FileSystem & Writable Stream to implement log rotation by log-file's size.
4. Date based rotation could be implemented by TImer API, but I found it a bit too expensive for logging operation. One can anyway implement it without modifying the log API itself.

**Example**: `https://gist.github.com/1992459`
