### PR TITLE
Add linebreaks for window filesystems

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -111,8 +111,8 @@ Log.prototype = {
     stream.setEncoding('utf8');
     stream.on('data', function(chunk){
       buf += chunk;
-      if ('\n' != buf[buf.length - 1]) return;
-      buf.split('\n').map(function(line){
+      if ('\r\n' != buf[buf.length - 1]) return;
+      buf.split('\r\n').map(function(line){
         if (!line.length) return;
         try {
           var captures = line.match(/^\[([^\]]+)\] (\w+) (.*)/);
@@ -150,7 +150,7 @@ Log.prototype = {
           '[' + new Date + ']'
         + ' ' + levelStr
         + ' ' + msg
-        + '\n'
+        + '\r\n'
       );
     }
   },


### PR DESCRIPTION
On Windows all log entries are written in one line.
