### PR TITLE
Make log level optional

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -15,15 +15,20 @@ var EventEmitter = require('events').EventEmitter;
  * Initialize a `Loggeer` with the given log `level` defaulting
  * to __DEBUG__ and `stream` defaulting to _stdout_.
  *
- * @param {Number} level
+ * @param {Number} level optional
  * @param {Object} stream
  * @api public
  */
 
 var Log = exports = module.exports = function Log(level, stream){
-  if ('string' == typeof level) level = exports[level.toUpperCase()];
-  this.level = isFinite(level) ? level : this.DEBUG;
-  this.stream = stream || process.stdout;
+  if (level && (level.readable || level.writable)) {
+    this.level = exports.DEBUG;
+    this.stream = level;
+  } else {
+    if ('string' == typeof level) level = exports[level.toUpperCase()];
+    this.level = isFinite(level) ? level : exports.DEBUG;
+    this.stream = stream || process.stdout;
+  }
   if (this.stream.readable) this.read();
 };
 


### PR DESCRIPTION
This allows for

``` js
var Log = require("log")
  , log = new Log(someStream);
```
