### PR TITLE
bump patch version for repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "log",
   "description": "Tiny logger with streaming reader",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "keywords": [
     "log",


### PR DESCRIPTION
The `repository` field was added in commit 8a9a49e1f84a06eb84606298aef9d0bccc6608ef, but the version number was not incremented, so `npm publish` was not possible.

Please merge + `npm publish`

thanks,  
Chris
