### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "log",
   "description": "Tiny logger with streaming reader",
   "version": "1.4.0",
+  "license": "MIT",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "keywords": [
     "log",


### PR DESCRIPTION
This adds the license - already present in the README - to the package.json. This helps with license checkers, and should remove log from http://npm1k.org/.